### PR TITLE
Fix No rule to make target 'ChangeLog.txt'#19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ palettes: $(PALETTES)
 
 
 $(ARCHIVE): $(BINARY) $(FOLDER)/$(DLL) $(FOLDER)/$(LAUNCHER) $(FOLDER)/$(UPDATER)
-$(ARCHIVE): $(FOLDER)/$(README) $(FOLDER)/$(CHANGELOG) $(FOLDER)/trials
+$(ARCHIVE): $(FOLDER)/$(README) $(FOLDER)/trials
 	@echo
 ifneq (,$(findstring release,$(MAKECMDGOALS)))
 		rm -f $(wildcard $(NAME)*.zip)


### PR DESCRIPTION
Exclude 'cccaster/ChangeLog.txt' from build and release.

Fix for " No rule to make target 'ChangeLog.txt', needed by 'cccaster/ChangeLog.txt' #19 ".

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [CCCaster Style Guide] _recently_, and have followed its advice.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene
[test-exempt]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#tests
[CCCaster Style Guide]: https://github.com/lurkydismal/CCCaster/wiki/Style-guide-for-CCCaster-repo
[CCCaster/tests]: https://github.com/lurkydismal/CCCaster/tests
[breaking change policy]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#handling-breaking-changes
