### PR TITLE
Close error: ‘UINT’ does not name a type #23 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -101,30 +101,34 @@ ForEachMacros:
   - BOOST_FOREACH
 IfMacros:
   - KJ_IF_MAYBE
-IncludeBlocks:   Preserve
+IncludeBlocks:   Regroup
 IncludeCategories:
+  - Regex:           '^<windows.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^<ext/.*\.h>'
-    Priority:        2
+    Priority:        3
     SortPriority:    0
     CaseSensitive:   false
   - Regex:           '^<.*\.h>'
-    Priority:        1
+    Priority:        2
     SortPriority:    0
     CaseSensitive:   false
   - Regex:           '^<ext/.*\.hpp>'
-    Priority:        2
+    Priority:        3
     SortPriority:    0
     CaseSensitive:   false
   - Regex:           '^<.*\.hpp>'
-    Priority:        1
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^<.*'
     Priority:        2
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '.*'
+  - Regex:           '^<.*'
     Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        4
     SortPriority:    0
     CaseSensitive:   false
 IncludeIsMainRegex: '([-_](test|unittest))?$'

--- a/lib/BlockingQueue.hpp
+++ b/lib/BlockingQueue.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Thread.hpp"
-
 #include <list>
 #include <unordered_set>
+
+#include "Thread.hpp"
 
 template < typename T >
 class BlockingQueue {

--- a/lib/Compression.cpp
+++ b/lib/Compression.cpp
@@ -1,4 +1,5 @@
 #include "Compression.hpp"
+
 #include "Logger.hpp"
 
 #define MINIZ_NO_ZLIB_COMPATIBLE_NAMES

--- a/lib/ConsoleUi.cpp
+++ b/lib/ConsoleUi.cpp
@@ -1,10 +1,11 @@
 #include "ConsoleUi.hpp"
-#include "Algorithms.hpp"
-#include "StringUtils.hpp"
 
 #include <windows.h>
 
 #include <climits>
+
+#include "Algorithms.hpp"
+#include "StringUtils.hpp"
 
 using namespace std;
 

--- a/lib/ConsoleUi.hpp
+++ b/lib/ConsoleUi.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "Logger.hpp"
-
 #include <JLib/ConsoleCore.h>
 
 #include <memory>
 #include <sstream>
 #include <vector>
+
+#include "Logger.hpp"
 
 // Operators
 inline COORD operator+( const COORD& a, const COORD& b ) {

--- a/lib/Controller.cpp
+++ b/lib/Controller.cpp
@@ -1,13 +1,14 @@
 #include "Controller.hpp"
-#include "Constants.hpp"
-#include "ControllerManager.hpp"
-#include "ErrorStrings.hpp"
-#include "Exceptions.hpp"
 
 #include <windows.h>
 
 #include <cstdlib>
 #include <limits>
+
+#include "Constants.hpp"
+#include "ControllerManager.hpp"
+#include "ErrorStrings.hpp"
+#include "Exceptions.hpp"
 
 using namespace std;
 

--- a/lib/Controller.hpp
+++ b/lib/Controller.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "Algorithms.hpp"
-#include "Guid.hpp"
-#include "KeyboardManager.hpp"
-#include "Thread.hpp"
-
 #include <array>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+
+#include "Algorithms.hpp"
+#include "Guid.hpp"
+#include "KeyboardManager.hpp"
+#include "Thread.hpp"
 
 #define LOG_CONTROLLER( CONTROLLER, FORMAT, ... )                           \
     LOG( "%s: controller=%08x; state=%08x; " FORMAT, CONTROLLER->getName(), \

--- a/lib/ControllerManager.cpp
+++ b/lib/ControllerManager.cpp
@@ -1,4 +1,5 @@
 #include "ControllerManager.hpp"
+
 #include "ErrorStrings.hpp"
 #include "Exceptions.hpp"
 
@@ -6,8 +7,9 @@
 #define DIRECTINPUT_VERSION 0x0800 // Need at least version 8
 #include <dinput.h>
 #define COBJMACROS
-#include <mmsystem.h>
 #include <windows.h>
+
+#include <mmsystem.h>
 
 #include <algorithm>
 #include <fstream>

--- a/lib/ControllerManager.hpp
+++ b/lib/ControllerManager.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "Controller.hpp"
-#include "Guid.hpp"
-#include "JoystickDetector.hpp"
-#include "Thread.hpp"
-
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#include "Controller.hpp"
+#include "Guid.hpp"
+#include "JoystickDetector.hpp"
+#include "Thread.hpp"
 
 struct ControllerMappings : public SerializableSequence {
     std::unordered_map< std::string, MsgPtr > mappings;

--- a/lib/Enum.hpp
+++ b/lib/Enum.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "StringUtils.hpp"
+#include <cereal/archives/binary.hpp>
 
 #include <string>
 #include <vector>
 
-#include <cereal/archives/binary.hpp>
+#include "StringUtils.hpp"
 
 // Enum type boilerplate code
 #define ENUM_BOILERPLATE( NAME, ... )                                 \

--- a/lib/EventManager.cpp
+++ b/lib/EventManager.cpp
@@ -1,12 +1,14 @@
 #include "EventManager.hpp"
+
+#include <windows.h>
+
+#include <mmsystem.h>
+#include <winsock2.h>
+
 #include "ControllerManager.hpp"
 #include "Logger.hpp"
 #include "SocketManager.hpp"
 #include "TimerManager.hpp"
-
-#include <mmsystem.h>
-#include <windows.h>
-#include <winsock2.h>
 
 using namespace std;
 

--- a/lib/EventManager.hpp
+++ b/lib/EventManager.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <memory>
+
 #include "BlockingQueue.hpp"
 #include "Thread.hpp"
-
-#include <memory>
 
 #define CHECK_TIMERS 0x0001
 #define CHECK_SOCKETS 0x0002

--- a/lib/Exceptions.cpp
+++ b/lib/Exceptions.cpp
@@ -1,9 +1,11 @@
 #include "Exceptions.hpp"
-#include "StringUtils.hpp"
 
 #include <windows.h>
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
+
+#include "StringUtils.hpp"
 
 using namespace std;
 

--- a/lib/ExternalIpAddress.cpp
+++ b/lib/ExternalIpAddress.cpp
@@ -1,7 +1,8 @@
 #include "ExternalIpAddress.hpp"
-#include "Logger.hpp"
 
 #include <vector>
+
+#include "Logger.hpp"
 
 using namespace std;
 

--- a/lib/ExternalIpAddress.hpp
+++ b/lib/ExternalIpAddress.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "HttpGet.hpp"
-
 #include <memory>
 #include <string>
+
+#include "HttpGet.hpp"
 
 class ExternalIpAddress : private HttpGet::Owner {
    public:

--- a/lib/GoBackN.cpp
+++ b/lib/GoBackN.cpp
@@ -1,9 +1,10 @@
 #include "GoBackN.hpp"
-#include "Logger.hpp"
 
 #include <cereal/types/string.hpp>
 
 #include <string>
+
+#include "Logger.hpp"
 
 using namespace std;
 

--- a/lib/GoBackN.hpp
+++ b/lib/GoBackN.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <list>
+
 #include "Protocol.hpp"
 #include "Timer.hpp"
-
-#include <list>
 
 #define DEFAULT_SEND_INTERVAL ( 50 )
 

--- a/lib/Guid.cpp
+++ b/lib/Guid.cpp
@@ -1,9 +1,10 @@
 #include "Guid.hpp"
-#include "Logger.hpp"
+
+#include <rpc.h>
 
 #include <algorithm>
 
-#include <rpc.h>
+#include "Logger.hpp"
 
 using namespace std;
 

--- a/lib/Guid.hpp
+++ b/lib/Guid.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <cstring>
+
 #include "Algorithms.hpp"
 #include "StringUtils.hpp"
-
-#include <cstring>
 
 // Windows GUID type forward declaration
 typedef struct _GUID GUID;

--- a/lib/HttpDownload.cpp
+++ b/lib/HttpDownload.cpp
@@ -1,4 +1,5 @@
 #include "HttpDownload.hpp"
+
 #include "Logger.hpp"
 
 using namespace std;

--- a/lib/HttpDownload.hpp
+++ b/lib/HttpDownload.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "HttpGet.hpp"
-
 #include <fstream>
 #include <memory>
 #include <string>
+
+#include "HttpGet.hpp"
 
 class HttpDownload : private HttpGet::Owner {
    public:

--- a/lib/HttpGet.cpp
+++ b/lib/HttpGet.cpp
@@ -1,8 +1,9 @@
 #include "HttpGet.hpp"
-#include "Exceptions.hpp"
-#include "TcpSocket.hpp"
 
 #include <sstream>
+
+#include "Exceptions.hpp"
+#include "TcpSocket.hpp"
 
 using namespace std;
 

--- a/lib/HttpGet.hpp
+++ b/lib/HttpGet.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <string>
+
 #include "Socket.hpp"
 #include "Timer.hpp"
-
-#include <string>
 
 #define DEFAULT_GET_TIMEOUT ( 5000 )
 

--- a/lib/IpAddrPort.cpp
+++ b/lib/IpAddrPort.cpp
@@ -1,12 +1,14 @@
 #include "IpAddrPort.hpp"
-#include "ErrorStrings.hpp"
-#include "Exceptions.hpp"
 
 #include <windows.h>
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
 #include <cctype>
+
+#include "ErrorStrings.hpp"
+#include "Exceptions.hpp"
 
 using namespace std;
 

--- a/lib/IpAddrPort.hpp
+++ b/lib/IpAddrPort.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "Algorithms.hpp"
-#include "Protocol.hpp"
-
 #include <cereal/types/string.hpp>
 
 #include <memory>
+
+#include "Algorithms.hpp"
+#include "Protocol.hpp"
 
 struct addrinfo;
 struct sockaddr;

--- a/lib/JoystickDetector.cpp
+++ b/lib/JoystickDetector.cpp
@@ -1,4 +1,5 @@
 #include "JoystickDetector.hpp"
+
 #include "ControllerManager.hpp"
 #include "ErrorStrings.hpp"
 #include "Exceptions.hpp"
@@ -6,9 +7,10 @@
 #include "UdpSocket.hpp"
 
 #define INITGUID
+#include <windows.h>
+
 #include <dbt.h>
 #include <oleauto.h>
-#include <windows.h>
 
 using namespace std;
 

--- a/lib/KeyValueStore.cpp
+++ b/lib/KeyValueStore.cpp
@@ -1,9 +1,10 @@
 #include "KeyValueStore.hpp"
-#include "Logger.hpp"
-#include "StringUtils.hpp"
 
 #include <fstream>
 #include <sstream>
+
+#include "Logger.hpp"
+#include "StringUtils.hpp"
 
 using namespace std;
 

--- a/lib/KeyboardManager.cpp
+++ b/lib/KeyboardManager.cpp
@@ -1,10 +1,12 @@
 #include "KeyboardManager.hpp"
+
+#include <windows.h>
+
+#include <mmsystem.h>
+
 #include "Exceptions.hpp"
 #include "Logger.hpp"
 #include "UdpSocket.hpp"
-
-#include <mmsystem.h>
-#include <windows.h>
 
 using namespace std;
 

--- a/lib/KeyboardManager.hpp
+++ b/lib/KeyboardManager.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <unordered_set>
+
 #include "Protocol.hpp"
 #include "Socket.hpp"
-
-#include <unordered_set>
 
 struct KeyboardEvent : public SerializableMessage {
     uint32_t vkCode = 0;

--- a/lib/KeyboardState.hpp
+++ b/lib/KeyboardState.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "TimerManager.hpp"
-
 #include <unordered_map>
+
+#include "TimerManager.hpp"
 
 #define DEFAULT_HELD_DURATION ( 300 )
 

--- a/lib/Lobby.cpp
+++ b/lib/Lobby.cpp
@@ -1,4 +1,5 @@
 #include "Lobby.hpp"
+
 #include "ConsoleUi.hpp"
 #include "EventManager.hpp"
 #include "Exceptions.hpp"

--- a/lib/Logger.cpp
+++ b/lib/Logger.cpp
@@ -1,4 +1,5 @@
 #include "Logger.hpp"
+
 #include "Algorithms.hpp"
 #include "TimerManager.hpp"
 

--- a/lib/Logger.hpp
+++ b/lib/Logger.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "StringUtils.hpp"
-#include "Thread.hpp"
-
 #include <cstdio>
 #include <ctime>
 #include <string>
+
+#include "StringUtils.hpp"
+#include "Thread.hpp"
 
 #define LOG_GM_TIME ( 0x01 )     // Log the gmtime timestamp per message
 #define LOG_LOCAL_TIME ( 0x02 )  // Log the localtime timestamp per message

--- a/lib/MatchmakingManager.cpp
+++ b/lib/MatchmakingManager.cpp
@@ -1,4 +1,5 @@
 #include "MatchmakingManager.hpp"
+
 #include "ConsoleUi.hpp"
 #include "EventManager.hpp"
 #include "Exceptions.hpp"

--- a/lib/MemDump.cpp
+++ b/lib/MemDump.cpp
@@ -1,12 +1,13 @@
 #include "MemDump.hpp"
-#include "Algorithms.hpp"
-#include "Compression.hpp"
 
 #include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <list>
 #include <sstream>
+
+#include "Algorithms.hpp"
+#include "Compression.hpp"
 
 using namespace std;
 using namespace cereal;

--- a/lib/MemDump.hpp
+++ b/lib/MemDump.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "Logger.hpp"
-
 #include <cereal/archives/binary.hpp>
 
 #include <string>
 #include <vector>
+
+#include "Logger.hpp"
 
 class MemDumpPtr;
 

--- a/lib/Pinger.cpp
+++ b/lib/Pinger.cpp
@@ -1,4 +1,5 @@
 #include "Pinger.hpp"
+
 #include "Logger.hpp"
 #include "TimerManager.hpp"
 

--- a/lib/Protocol.cpp
+++ b/lib/Protocol.cpp
@@ -1,4 +1,5 @@
 #include "Protocol.hpp"
+
 #include "Compression.hpp"
 #include "Enum.hpp"
 #include "Logger.hpp"

--- a/lib/Protocol.hpp
+++ b/lib/Protocol.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "Enum.hpp"
-
 #include <cereal/archives/binary.hpp>
 
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
+
+#include "Enum.hpp"
 
 #define EMPTY_MESSAGE_BOILERPLATE( NAME ) \
     NAME() {}                             \

--- a/lib/SmartSocket.cpp
+++ b/lib/SmartSocket.cpp
@@ -1,10 +1,12 @@
 #include "SmartSocket.hpp"
+
+#include <ws2tcpip.h>
+
+#include <fstream>
+
 #include "Logger.hpp"
 #include "TcpSocket.hpp"
 #include "UdpSocket.hpp"
-
-#include <ws2tcpip.h>
-#include <fstream>
 
 using namespace std;
 

--- a/lib/SmartSocket.hpp
+++ b/lib/SmartSocket.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "Socket.hpp"
 #include "Timer.hpp"
-
-#include <unordered_map>
 
 // Socket class that tries to listen / connect over the desired protocol, but
 // automatically falls back to using UDP tunnel if the initial protocol fails.

--- a/lib/Socket.cpp
+++ b/lib/Socket.cpp
@@ -1,19 +1,20 @@
 #include "Socket.hpp"
+
+#include <windows.h>
+
+#include <cereal/types/unordered_map.hpp>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include <algorithm>
+#include <unordered_set>
+
 #include "ErrorStrings.hpp"
 #include "Exceptions.hpp"
 #include "SmartSocket.hpp"
 #include "SocketManager.hpp"
 #include "TcpSocket.hpp"
 #include "UdpSocket.hpp"
-
-#include <windows.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-
-#include <cereal/types/unordered_map.hpp>
-
-#include <algorithm>
-#include <unordered_set>
 
 using namespace std;
 

--- a/lib/Socket.hpp
+++ b/lib/Socket.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "Enum.hpp"
 #include "GoBackN.hpp"
 #include "IpAddrPort.hpp"
-
-#include <memory>
-#include <vector>
 
 #define DEFAULT_CONNECT_TIMEOUT ( 5000 )
 

--- a/lib/SocketManager.cpp
+++ b/lib/SocketManager.cpp
@@ -1,11 +1,13 @@
 #include "SocketManager.hpp"
+
+#include <windows.h>
+
+#include <winsock2.h>
+
 #include "ErrorStrings.hpp"
 #include "Exceptions.hpp"
 #include "Socket.hpp"
 #include "TimerManager.hpp"
-
-#include <windows.h>
-#include <winsock2.h>
 
 using namespace std;
 

--- a/lib/Statistics.hpp
+++ b/lib/Statistics.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "Logger.hpp"
-#include "Protocol.hpp"
-
 #include <algorithm>
 #include <cmath>
 #include <limits>
+
+#include "Logger.hpp"
+#include "Protocol.hpp"
 
 // Template class to calculate stats with an online algorithm
 class Statistics : public SerializableSequence {

--- a/lib/TcpSocket.cpp
+++ b/lib/TcpSocket.cpp
@@ -1,14 +1,16 @@
 #include "TcpSocket.hpp"
-#include "ErrorStrings.hpp"
-#include "Exceptions.hpp"
-#include "Protocol.hpp"
-#include "SocketManager.hpp"
 
 #include <windows.h>
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
 #include <algorithm>
+
+#include "ErrorStrings.hpp"
+#include "Exceptions.hpp"
+#include "Protocol.hpp"
+#include "SocketManager.hpp"
 
 using namespace std;
 

--- a/lib/Timer.cpp
+++ b/lib/Timer.cpp
@@ -1,4 +1,5 @@
 #include "Timer.hpp"
+
 #include "TimerManager.hpp"
 
 using namespace std;

--- a/lib/TimerManager.cpp
+++ b/lib/TimerManager.cpp
@@ -1,9 +1,11 @@
 #include "TimerManager.hpp"
-#include "Logger.hpp"
-#include "Timer.hpp"
+
+#include <windows.h>
 
 #include <mmsystem.h>
-#include <windows.h>
+
+#include "Logger.hpp"
+#include "Timer.hpp"
 
 using namespace std;
 

--- a/lib/UdpSocket.cpp
+++ b/lib/UdpSocket.cpp
@@ -1,15 +1,17 @@
 #include "UdpSocket.hpp"
-#include "ErrorStrings.hpp"
-#include "Exceptions.hpp"
-#include "Protocol.hpp"
-#include "SocketManager.hpp"
 
 #include <windows.h>
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
 #include <algorithm>
 #include <typeinfo>
+
+#include "ErrorStrings.hpp"
+#include "Exceptions.hpp"
+#include "Protocol.hpp"
+#include "SocketManager.hpp"
 
 using namespace std;
 

--- a/lib/Version.hpp
+++ b/lib/Version.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Protocol.hpp"
-
 #include <cereal/types/string.hpp>
 
 #include <string>
+
+#include "Protocol.hpp"
 
 class Version : public SerializableSequence {
    public:

--- a/netplay/InputsContainer.hpp
+++ b/netplay/InputsContainer.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Constants.hpp"
-#include "Logger.hpp"
-
 #include <algorithm>
 #include <vector>
+
+#include "Constants.hpp"
+#include "Logger.hpp"
 
 template < typename T >
 class InputsContainer {

--- a/netplay/Messages.hpp
+++ b/netplay/Messages.hpp
@@ -1,13 +1,5 @@
 #pragma once
 
-#include "CharacterSelect.hpp"
-#include "Compression.hpp"
-#include "Constants.hpp"
-#include "Logger.hpp"
-#include "Protocol.hpp"
-#include "Statistics.hpp"
-#include "Version.hpp"
-
 #include <cereal/types/array.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/unordered_map.hpp>
@@ -15,6 +7,14 @@
 
 #include <array>
 #include <cstring>
+
+#include "CharacterSelect.hpp"
+#include "Compression.hpp"
+#include "Constants.hpp"
+#include "Logger.hpp"
+#include "Protocol.hpp"
+#include "Statistics.hpp"
+#include "Version.hpp"
 
 struct ErrorMessage : public SerializableSequence {
     std::string error;

--- a/netplay/Options.hpp
+++ b/netplay/Options.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "Enum.hpp"
-#include "Protocol.hpp"
-
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "Enum.hpp"
+#include "Protocol.hpp"
 
 // Set of command line options
 ENUM( Options,

--- a/netplay/PaletteManager.cpp
+++ b/netplay/PaletteManager.cpp
@@ -1,9 +1,10 @@
 #include "PaletteManager.hpp"
-#include "Algorithms.hpp"
-#include "StringUtils.hpp"
 
 #include <fstream>
 #include <sstream>
+
+#include "Algorithms.hpp"
+#include "StringUtils.hpp"
 
 using namespace std;
 

--- a/netplay/PaletteManager.hpp
+++ b/netplay/PaletteManager.hpp
@@ -2,6 +2,7 @@
 
 #ifndef DISABLE_SERIALIZATION
 #include <cereal/types/map.hpp>
+
 #include "Protocol.hpp"
 #endif
 

--- a/netplay/ProcessManager.cpp
+++ b/netplay/ProcessManager.cpp
@@ -1,18 +1,20 @@
 #include "ProcessManager.hpp"
+
+#include <windows.h>
+
+#include <direct.h>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
 #include "Constants.hpp"
 #include "ErrorStringsExt.hpp"
 #include "EventManager.hpp"
 #include "Exceptions.hpp"
 #include "Messages.hpp"
 #include "TcpSocket.hpp"
-
-#include <direct.h>
-#include <windows.h>
-
-#include <algorithm>
-#include <fstream>
-#include <iostream>
-#include <memory>
 
 using namespace std;
 

--- a/netplay/ProcessManager.hpp
+++ b/netplay/ProcessManager.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <array>
+
 #include "Messages.hpp"
 #include "Protocol.hpp"
 #include "Socket.hpp"
 #include "Timer.hpp"
-
-#include <array>
 
 #define COMBINE_INPUT( DIRECTION, BUTTONS ) \
     uint16_t( ( DIRECTION ) | ( ( BUTTONS ) << 4 ) )

--- a/netplay/ReplayCreator.cpp
+++ b/netplay/ReplayCreator.cpp
@@ -1,15 +1,17 @@
 #include "ReplayCreator.hpp"
-#include "StringUtils.hpp"
 
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
+
+#include "StringUtils.hpp"
 using namespace std;
 
 void ReplayCreator::dump( ReplayCreator::ReplayFile rf, char* fname ) {

--- a/netplay/ReplayCreator.hpp
+++ b/netplay/ReplayCreator.hpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+
 #include "Logger.hpp"
 
 #define BUTTON_UP( BEFORE, AFTER ) uint8_t( ~( ( ~BEFORE ) | AFTER ) )

--- a/netplay/ReplayManager.cpp
+++ b/netplay/ReplayManager.cpp
@@ -1,10 +1,11 @@
 #include "ReplayManager.hpp"
-#include "Exceptions.hpp"
-#include "Logger.hpp"
-#include "Messages.hpp"
 
 #include <fstream>
 #include <iostream>
+
+#include "Exceptions.hpp"
+#include "Logger.hpp"
+#include "Messages.hpp"
 
 using namespace std;
 

--- a/netplay/ReplayManager.hpp
+++ b/netplay/ReplayManager.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Constants.hpp"
-#include "Protocol.hpp"
-
 #include <string>
 #include <vector>
+
+#include "Constants.hpp"
+#include "Protocol.hpp"
 
 class ReplayManager {
    public:

--- a/netplay/SpectatorManager.cpp
+++ b/netplay/SpectatorManager.cpp
@@ -1,4 +1,5 @@
 #include "SpectatorManager.hpp"
+
 #include "Logger.hpp"
 #include "ProcessManager.hpp"
 

--- a/netplay/SpectatorManager.hpp
+++ b/netplay/SpectatorManager.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <list>
+#include <unordered_map>
+
 #include "Constants.hpp"
 #include "Socket.hpp"
 #include "Timer.hpp"
-
-#include <list>
-#include <unordered_map>
 
 // Default pending socket timeout
 #define DEFAULT_PENDING_TIMEOUT ( 20000 )

--- a/targets/DllAsmHacks.cpp
+++ b/targets/DllAsmHacks.cpp
@@ -1,15 +1,18 @@
 #include "DllAsmHacks.hpp"
+
+#include <windows.h>
+
+#include <d3dx9.h>
+
+#include <fstream>
+#include <iterator>
+#include <vector>
+
 #include "CharacterSelect.hpp"
 #include "DllNetplayManager.hpp"
 #include "DllTrialManager.hpp"
 #include "Logger.hpp"
 #include "Messages.hpp"
-
-#include <d3dx9.h>
-#include <windows.h>
-#include <fstream>
-#include <iterator>
-#include <vector>
 
 using namespace std;
 

--- a/targets/DllControllerManager.cpp
+++ b/targets/DllControllerManager.cpp
@@ -1,12 +1,13 @@
 #include "DllControllerManager.hpp"
+
+#include <windows.h>
+
 #include "CharacterSelect.hpp"
 #include "DllAsmHacks.hpp"
 #include "DllHacks.hpp"
 #include "DllOverlayUi.hpp"
 #include "DllTrialManager.hpp"
 #include "KeyboardState.hpp"
-
-#include <windows.h>
 
 using namespace std;
 

--- a/targets/DllFrameRate.cpp
+++ b/targets/DllFrameRate.cpp
@@ -1,10 +1,11 @@
 #include "DllFrameRate.hpp"
+
+#include <d3dx9.h>
+
 #include "Constants.hpp"
 #include "DllAsmHacks.hpp"
 #include "ProcessManager.hpp"
 #include "TimerManager.hpp"
-
-#include <d3dx9.h>
 
 using namespace std;
 using namespace DllFrameRate;

--- a/targets/DllHacks.cpp
+++ b/targets/DllHacks.cpp
@@ -1,6 +1,8 @@
 #include "DllHacks.hpp"
+
 #include "Algorithms.hpp"
 #include "ControllerManager.hpp"
+#include "D3DHook.h"
 #include "DllAsmHacks.hpp"
 #include "DllFrameRate.hpp"
 #include "Exceptions.hpp"
@@ -8,12 +10,11 @@
 #include "MouseManager.hpp"
 #include "ProcessManager.hpp"
 
-#include "D3DHook.h"
-
 #define INITGUID
+#include <windows.h>
+
 #include <MinHook.h>
 #include <dbt.h>
-#include <windows.h>
 #include <windowsx.h>
 
 using namespace std;

--- a/targets/DllMain.cpp
+++ b/targets/DllMain.cpp
@@ -1,3 +1,9 @@
+#include <windows.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 #include "ChangeMonitor.hpp"
 #include "CharacterSelect.hpp"
 #include "DllControllerManager.hpp"
@@ -17,12 +23,6 @@
 #include "SpectatorManager.hpp"
 #include "Thread.hpp"
 #include "UdpSocket.hpp"
-
-#include <windows.h>
-
-#include <algorithm>
-#include <memory>
-#include <vector>
 
 using namespace std;
 

--- a/targets/DllNetplayManager.cpp
+++ b/targets/DllNetplayManager.cpp
@@ -1,10 +1,4 @@
 #include "DllNetplayManager.hpp"
-#include "CharacterSelect.hpp"
-#include "DllAsmHacks.hpp"
-#include "DllTrialManager.hpp"
-#include "Exceptions.hpp"
-#include "ProcessManager.hpp"
-#include "ReplayCreator.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -12,6 +6,13 @@
 #include <fstream>
 #include <unordered_map>
 #include <unordered_set>
+
+#include "CharacterSelect.hpp"
+#include "DllAsmHacks.hpp"
+#include "DllTrialManager.hpp"
+#include "Exceptions.hpp"
+#include "ProcessManager.hpp"
+#include "ReplayCreator.hpp"
 
 using namespace std;
 

--- a/targets/DllNetplayManager.hpp
+++ b/targets/DllNetplayManager.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <climits>
+#include <vector>
+
 #include "InputsContainer.hpp"
 #include "Messages.hpp"
 #include "NetplayStates.hpp"
-
-#include <climits>
-#include <vector>
 
 // Class that manages netplay state and inputs
 class NetplayManager {

--- a/targets/DllOverlayPrimitives.hpp
+++ b/targets/DllOverlayPrimitives.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #define M_PI 3.14159265358979323846
+#include <windows.h>
+
+#include <d3dx9.h>
+
 #include <array>
 #include <cmath>
 #include <string>
-
-#include <d3dx9.h>
-#include <windows.h>
 
 #define COLOR_BLACK D3DCOLOR_XRGB( 0, 0, 0 )
 #define COLOR_WHITE D3DCOLOR_XRGB( 255, 255, 255 )

--- a/targets/DllOverlayUi.cpp
+++ b/targets/DllOverlayUi.cpp
@@ -1,12 +1,12 @@
 #include "DllOverlayUi.hpp"
+
+#include <d3dx9.h>
+
 #include "Constants.hpp"
 #include "ProcessManager.hpp"
-
 #include "imgui.h"
 #include "imgui_impl_dx9.h"
 #include "imgui_impl_win32.h"
-
-#include <d3dx9.h>
 
 using namespace std;
 using namespace DllOverlayUi;

--- a/targets/DllOverlayUi.hpp
+++ b/targets/DllOverlayUi.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <d3dx9.h>
+
 #include <array>
 #include <string>
 

--- a/targets/DllOverlayUiImGui.cpp
+++ b/targets/DllOverlayUiImGui.cpp
@@ -1,12 +1,11 @@
+#include <d3dx9.h>
+
 #include "Constants.hpp"
 #include "DllOverlayUi.hpp"
 #include "ProcessManager.hpp"
-
 #include "imgui.h"
 #include "imgui_impl_dx9.h"
 #include "imgui_impl_win32.h"
-
-#include <d3dx9.h>
 
 using namespace std;
 using namespace DllOverlayUi;

--- a/targets/DllOverlayUiText.cpp
+++ b/targets/DllOverlayUiText.cpp
@@ -1,16 +1,18 @@
+#include <windows.h>
+
+#include <d3dx9.h>
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
 #include "DllHacks.hpp"
 #include "DllOverlayPrimitives.hpp"
 #include "DllOverlayUi.hpp"
 #include "DllTrialManager.hpp"
 #include "Enum.hpp"
 #include "ProcessManager.hpp"
-
-#include <d3dx9.h>
-#include <windows.h>
-#include <fstream>
-#include <iostream>
-#include <iterator>
-#include <vector>
 
 using namespace std;
 using namespace DllOverlayUi;

--- a/targets/DllProcessManager.cpp
+++ b/targets/DllProcessManager.cpp
@@ -1,11 +1,12 @@
+#include <windows.h>
+
+#include <direct.h>
+
 #include "Constants.hpp"
 #include "ErrorStringsExt.hpp"
 #include "Exceptions.hpp"
 #include "ProcessManager.hpp"
 #include "TcpSocket.hpp"
-
-#include <direct.h>
-#include <windows.h>
 
 using namespace std;
 

--- a/targets/DllRollbackManager.cpp
+++ b/targets/DllRollbackManager.cpp
@@ -1,10 +1,11 @@
 #include "DllRollbackManager.hpp"
-#include "DllAsmHacks.hpp"
-#include "ErrorStringsExt.hpp"
-#include "MemDump.hpp"
 
 #include <algorithm>
 #include <utility>
+
+#include "DllAsmHacks.hpp"
+#include "ErrorStringsExt.hpp"
+#include "MemDump.hpp"
 
 using namespace std;
 

--- a/targets/DllRollbackManager.hpp
+++ b/targets/DllRollbackManager.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "Constants.hpp"
-#include "DllNetplayManager.hpp"
-
 #include <array>
 #include <cfenv>
 #include <list>
 #include <memory>
 #include <stack>
+
+#include "Constants.hpp"
+#include "DllNetplayManager.hpp"
 
 struct __attribute__( ( packed ) ) RepInputState {
     char unk1;

--- a/targets/DllTrialManager.cpp
+++ b/targets/DllTrialManager.cpp
@@ -1,4 +1,14 @@
 #include "DllTrialManager.hpp"
+
+#include <windows.h>
+
+#include <mmsystem.h>
+
+#include <codecvt>
+#include <fstream>
+#include <locale>
+#include <string>
+
 #include "CharacterSelect.hpp"
 #include "Constants.hpp"
 #include "DllNetplayManager.hpp"
@@ -8,13 +18,6 @@
 #include "Sequences.hpp"
 #include "Shlwapi.h"
 #include "StringUtils.hpp"
-
-#include <mmsystem.h>
-#include <windows.h>
-#include <codecvt>
-#include <fstream>
-#include <locale>
-#include <string>
 
 using namespace std;
 

--- a/targets/DllTrialManager.hpp
+++ b/targets/DllTrialManager.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <vector>
-
 #include <d3dx9.h>
+
+#include <vector>
 
 using namespace std;
 

--- a/targets/Main.cpp
+++ b/targets/Main.cpp
@@ -1,16 +1,19 @@
 #include "Main.hpp"
+
+#include <windows.h>
+
+#include <optionparser.h>
+
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+
 #include "ConsoleUi.hpp"
 #include "Exceptions.hpp"
 #include "MainUi.hpp"
 #include "StringUtils.hpp"
 #include "Test.hpp"
 #include "Version.hpp"
-
-#include <optionparser.h>
-#include <windows.h>
-#include <algorithm>
-#include <fstream>
-#include <iterator>
 
 using namespace std;
 using namespace option;

--- a/targets/Main.hpp
+++ b/targets/Main.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_set>
+
 #include "EventManager.hpp"
 #include "IpAddrPort.hpp"
 #include "KeyboardManager.hpp"
@@ -9,8 +11,6 @@
 #include "SocketManager.hpp"
 #include "Timer.hpp"
 #include "TimerManager.hpp"
-
-#include <unordered_set>
 
 // Log file that contains all the data needed to keep games in sync
 #define SYNC_LOG_FILE FOLDER "sync.log"

--- a/targets/MainApp.cpp
+++ b/targets/MainApp.cpp
@@ -1,3 +1,7 @@
+#include <windows.h>
+
+#include <ws2tcpip.h>
+
 #include "Algorithms.hpp"
 #include "CharacterSelect.hpp"
 #include "Constants.hpp"
@@ -10,9 +14,6 @@
 #include "SmartSocket.hpp"
 #include "SpectatorManager.hpp"
 #include "UdpSocket.hpp"
-
-#include <windows.h>
-#include <ws2tcpip.h>
 
 using namespace std;
 

--- a/targets/MainUi.cpp
+++ b/targets/MainUi.cpp
@@ -1,4 +1,11 @@
 #include "MainUi.hpp"
+
+#include <mmsystem.h>
+#include <wininet.h>
+
+#include <algorithm>
+#include <iomanip>
+
 #include "CharacterSelect.hpp"
 #include "ConsoleUi.hpp"
 #include "ErrorStringsExt.hpp"
@@ -7,11 +14,6 @@
 #include "NetplayStates.hpp"
 #include "StringUtils.hpp"
 #include "Version.hpp"
-
-#include <mmsystem.h>
-#include <wininet.h>
-#include <algorithm>
-#include <iomanip>
 
 using namespace std;
 

--- a/targets/MainUi.hpp
+++ b/targets/MainUi.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "Controller.hpp"
 #include "ControllerManager.hpp"
 #include "IpAddrPort.hpp"
@@ -8,9 +11,6 @@
 #include "MainUpdater.hpp"
 #include "MatchmakingManager.hpp"
 #include "Messages.hpp"
-
-#include <memory>
-#include <string>
 
 // The function to run the game with the provided options
 typedef void ( *RunFuncPtr )( const IpAddrPort& address,

--- a/targets/MainUpdater.cpp
+++ b/targets/MainUpdater.cpp
@@ -1,11 +1,12 @@
 #include "MainUpdater.hpp"
-#include "Logger.hpp"
-#include "ProcessManager.hpp"
+
+#include <windows.h>
 
 #include <unordered_set>
 #include <vector>
 
-#include <windows.h>
+#include "Logger.hpp"
+#include "ProcessManager.hpp"
 
 using namespace std;
 

--- a/targets/MainUpdater.hpp
+++ b/targets/MainUpdater.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <string>
+
 #include "Enum.hpp"
 #include "HttpDownload.hpp"
 #include "HttpGet.hpp"
 #include "Version.hpp"
-
-#include <string>
 
 class MainUpdater : private HttpDownload::Owner, private HttpGet::Owner {
    public:

--- a/tests/Test.GoBackN.cpp
+++ b/tests/Test.GoBackN.cpp
@@ -1,12 +1,12 @@
 #ifndef RELEASE
 
-#include "GoBackN.hpp"
-#include "Test.Socket.hpp"
-#include "UdpSocket.hpp"
-
 #include <gtest/gtest.h>
 
 #include <vector>
+
+#include "GoBackN.hpp"
+#include "Test.Socket.hpp"
+#include "UdpSocket.hpp"
 
 using namespace std;
 

--- a/tests/Test.Socket.hpp
+++ b/tests/Test.Socket.hpp
@@ -12,6 +12,12 @@ struct TestMessage : public SerializableSequence {
 
 #ifndef RELEASE
 
+#include <cereal/types/string.hpp>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
 #include "EventManager.hpp"
 #include "Logger.hpp"
 #include "Socket.hpp"
@@ -19,12 +25,6 @@ struct TestMessage : public SerializableSequence {
 #include "Timer.hpp"
 #include "TimerManager.hpp"
 #include "UdpSocket.hpp"
-
-#include <cereal/types/string.hpp>
-#include <gtest/gtest.h>
-
-#include <string>
-#include <vector>
 
 using namespace std;
 

--- a/tests/Test.Timer.cpp
+++ b/tests/Test.Timer.cpp
@@ -1,14 +1,14 @@
 #ifndef RELEASE
 
-#include "EventManager.hpp"
-#include "SocketManager.hpp"
-#include "Timer.hpp"
-#include "TimerManager.hpp"
-
 #include <gtest/gtest.h>
 
 #include <cstdlib>
 #include <vector>
+
+#include "EventManager.hpp"
+#include "SocketManager.hpp"
+#include "Timer.hpp"
+#include "TimerManager.hpp"
 
 using namespace std;
 

--- a/tests/Test.UdpSocket.cpp
+++ b/tests/Test.UdpSocket.cpp
@@ -1,10 +1,10 @@
 #ifndef RELEASE
 
+#include <memory>
+
 #include "Test.Socket.hpp"
 #include "Timer.hpp"
 #include "UdpSocket.hpp"
-
-#include <memory>
 
 using namespace std;
 

--- a/tools/Debugger.cpp
+++ b/tools/Debugger.cpp
@@ -1,11 +1,12 @@
+#include <windows.h>
+
+#include <distorm.h>
+#include <mnemonics.h>
+
 #include "Constants.hpp"
 #include "Exceptions.hpp"
 #include "Logger.hpp"
 #include "StringUtils.hpp"
-
-#include <distorm.h>
-#include <mnemonics.h>
-#include <windows.h>
 
 using namespace std;
 

--- a/tools/PaletteEditor.cpp
+++ b/tools/PaletteEditor.cpp
@@ -1,13 +1,13 @@
 #include "PaletteEditor.hpp"
-#include "Algorithms.hpp"
-#include "CharacterSelect.hpp"
-#include "StringUtils.hpp"
-
-#include "mbaacc_framedisplay.h"
 
 #include <direct.h>
 
 #include <cctype>
+
+#include "Algorithms.hpp"
+#include "CharacterSelect.hpp"
+#include "StringUtils.hpp"
+#include "mbaacc_framedisplay.h"
 
 using namespace std;
 

--- a/tools/Palettes.cpp
+++ b/tools/Palettes.cpp
@@ -1,15 +1,10 @@
-#include "Algorithms.hpp"
-#include "KeyValueStore.hpp"
-#include "PaletteEditor.hpp"
+#include <windows.h>
 
 #include <AntTweakBar.h>
-
+#include <direct.h>
 #include <gl.h>
 #include <glfw.h>
 #include <glu.h>
-
-#include <direct.h>
-#include <windows.h>
 
 #include <algorithm>
 #include <climits>
@@ -17,6 +12,10 @@
 #include <cstdarg>
 #include <string>
 #include <unordered_map>
+
+#include "Algorithms.hpp"
+#include "KeyValueStore.hpp"
+#include "PaletteEditor.hpp"
 
 using namespace std;
 

--- a/tools/Updater.cpp
+++ b/tools/Updater.cpp
@@ -1,9 +1,10 @@
-#include "StringUtils.hpp"
+#include <windows.h>
+
+#include <psapi.h>
 
 #include <cstdlib>
 
-#include <psapi.h>
-#include <windows.h>
+#include "StringUtils.hpp"
 
 using namespace std;
 


### PR DESCRIPTION
Change format file options to make <windows.h> first in the include groups.

Fix error: ‘UINT’ does not name a type#23  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [CCCaster Style Guide] _recently_, and have followed its advice.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene
[test-exempt]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#tests
[CCCaster Style Guide]: https://github.com/lurkydismal/CCCaster/wiki/Style-guide-for-CCCaster-repo
[CCCaster/tests]: https://github.com/lurkydismal/CCCaster/tests
[breaking change policy]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#handling-breaking-changes
