### PR TITLE
Close error: ‘uint64_t’ does not name a type. #25

### DIFF
--- a/lib/KeyboardState.hpp
+++ b/lib/KeyboardState.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <unordered_map>
 
 #include "TimerManager.hpp"

--- a/lib/SocketManager.hpp
+++ b/lib/SocketManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <unordered_set>
 
 class Socket;

--- a/lib/TimerManager.hpp
+++ b/lib/TimerManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <unordered_set>
 
 class Timer;

--- a/targets/DllTrialManager.hpp
+++ b/targets/DllTrialManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <d3dx9.h>
 
+#include <cstdint>
 #include <vector>
 
 using namespace std;


### PR DESCRIPTION
Include <cstdint> in failed to build files.

Fix for error: ‘uint64_t’ does not name a type. #25

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [CCCaster Style Guide] _recently_, and have followed its advice.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene
[test-exempt]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#tests
[CCCaster Style Guide]: https://github.com/lurkydismal/CCCaster/wiki/Style-guide-for-CCCaster-repo
[CCCaster/tests]: https://github.com/lurkydismal/CCCaster/tests
[breaking change policy]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#handling-breaking-changes
