### PR TITLE
Close error: ‘string’ does not name a type #29

### DIFF
--- a/targets/DllTrialManager.hpp
+++ b/targets/DllTrialManager.hpp
@@ -2,6 +2,7 @@
 #include <d3dx9.h>
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 using namespace std;

--- a/targets/DllTrialManager.hpp
+++ b/targets/DllTrialManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <d3dx9.h>
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Include \<string\> and \<array\> in failed to build files.

Fixes for error: ‘string’ does not name a type #29 and error: ‘array’ does not name a type

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [CCCaster Style Guide] _recently_, and have followed its advice.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene
[test-exempt]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#tests
[CCCaster Style Guide]: https://github.com/lurkydismal/CCCaster/wiki/Style-guide-for-CCCaster-repo
[CCCaster/tests]: https://github.com/lurkydismal/CCCaster/tests
[breaking change policy]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#handling-breaking-changes
