### PR TITLE
Close error: invalid conversion from ‘char’ to ‘ImGuiKey’ #31

### DIFF
--- a/targets/DllOverlayUiImGui.cpp
+++ b/targets/DllOverlayUiImGui.cpp
@@ -127,9 +127,11 @@ void EndScene( IDirect3DDevice9* device ) {
         ImGui::Text( "Position: %f, %f", mousePositionRelative.x,
                      mousePositionRelative.y );
 
-        ImGui::Text( "h = %d %d", ImGui::IsKeyPressed( 'h' ),
+        ImGui::Text( "h = %d %d",
+                     ImGui::IsKeyPressed( static_cast< ImGuiKey >( 'h' ) ),
                      GetAsyncKeyState( 0x48 ) );
-        ImGui::Text( "h = %d %d", ImGui::IsKeyPressed( 'h' ),
+        ImGui::Text( "h = %d %d",
+                     ImGui::IsKeyPressed( static_cast< ImGuiKey >( 'h' ) ),
                      GetAsyncKeyState( VK_LBUTTON ) );
         ImGui::Text(
             "Mouse clicked: %s",


### PR DESCRIPTION
static_cast `char` to `ImGuiKey`

Fix for error: invalid conversion from ‘char’ to ‘ImGuiKey’ #31

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [CCCaster Style Guide] _recently_, and have followed its advice.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene
[test-exempt]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#tests
[CCCaster Style Guide]: https://github.com/lurkydismal/CCCaster/wiki/Style-guide-for-CCCaster-repo
[CCCaster/tests]: https://github.com/lurkydismal/CCCaster/tests
[breaking change policy]: https://github.com/lurkydismal/CCCaster/wiki/Tree-hygiene#handling-breaking-changes
